### PR TITLE
Print 'T' before subday parts

### DIFF
--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -264,6 +264,8 @@ void PrintValue(std::ostream &os, const mg_duration *duration) {
   const auto time =
       chrono::duration_cast<chrono::microseconds>(seconds + nanoseconds);
 
+  const bool has_subdays = time.count() > 0;
+
   const auto hh = chrono::duration_cast<chrono::hours>(time);
   const auto mm = chrono::duration_cast<chrono::minutes>(time - hh);
   const auto ss = chrono::duration_cast<chrono::seconds>(time - hh - mm);
@@ -271,7 +273,12 @@ void PrintValue(std::ostream &os, const mg_duration *duration) {
       chrono::duration_cast<chrono::microseconds>(time - hh - mm - ss);
 
   os << "P";
-  PrintIfNotZero(os, days.count(), "DT");
+  PrintIfNotZero(os, days.count(), "D");
+
+  if (has_subdays) {
+    os << "T";
+  }
+
   PrintIfNotZero(os, hh.count(), "H");
   PrintIfNotZero(os, mm.count(), "M");
   if (ss.count() == 0 && mis.count() == 0) {


### PR DESCRIPTION
Without this change, if only minutes are present we would get `P3M` which actually represents months.