### PR TITLE
Bump version 1.5.1 and add Docker build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,7 @@ jobs:
   docker_build_and_test:
     name: Build and test mgconsole in Docker container
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -219,6 +220,22 @@ jobs:
       - name: Run latest Memgraph Docker container
         run: |
           docker run --rm -d --name memgraph --network host memgraph/memgraph:latest --telemetry-enabled=false
+
+      - name: Wait for Memgraph Bolt
+        run: |
+          host=127.0.0.1
+          port=7687
+          max_attempts=120
+          delay=1
+          for attempt in $(seq 1 "$max_attempts"); do
+            if bash -c "echo >/dev/tcp/${host}/${port}" 2>/dev/null; then
+              echo "Memgraph Bolt port open at ${host}:${port}"
+              exit 0
+            fi
+            sleep "$delay"
+          done
+          echo "Timeout waiting for Memgraph Bolt at ${host}:${port}"
+          exit 1
 
       - name: Test mgconsole in Docker container
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,3 +204,33 @@ jobs:
           elif [[ "${{ matrix.arch }}" == "ARM64" ]]; then
             docker rmi memgraph/mgbuild:v7_debian-12-arm || true
           fi
+
+  docker_build_and_test:
+    name: Build and test mgconsole in Docker container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Build and test mgconsole in Docker container
+        run: |
+          docker build -t mgconsole .
+
+      - name: Run latest Memgraph Docker container
+        run: |
+          docker run --rm -d --name memgraph --network host memgraph/memgraph:latest --telemetry-enabled=false
+
+      - name: Test mgconsole in Docker container
+        run: |
+          # Test pipe directly into docker run
+          echo "RETURN 1;" | docker run --network host mgconsole:latest
+
+          # Test entrypoint override with echo
+          docker run --network host --rm --entrypoint sh mgconsole:latest -c "echo 'RETURN 1;' | mgconsole"
+      
+      - name: Cleanup docker images
+        run: |
+          docker rmi mgconsole || true
+          docker stop memgraph || true
+          docker rm memgraph || true
+          docker rmi memgraph/memgraph:latest || true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 cmake_minimum_required(VERSION 3.10)
-project(mgconsole VERSION 1.5)
+project(mgconsole VERSION 1.5.1)
 include(CTest)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
- Bump `mgconsole` to version `1.5.1` for a new release.
- Added simple smoke test for piping queries into the Docker container image to avoid another regression (fixed by #94 ).